### PR TITLE
feat: add image attachments with client-side compression

### DIFF
--- a/apps/webclaw/src/components/attachment-button.tsx
+++ b/apps/webclaw/src/components/attachment-button.tsx
@@ -1,0 +1,275 @@
+'use client'
+
+import { useRef, useCallback } from 'react'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Attachment01Icon } from '@hugeicons/core-free-icons'
+
+import { Button } from '@/components/ui/button'
+
+/** Maximum file size before compression (10MB) */
+const MAX_FILE_SIZE = 10 * 1024 * 1024
+
+/** Maximum dimension (width or height) for resized images */
+const MAX_IMAGE_DIMENSION = 1280
+
+/** Initial JPEG compression quality (0-1) */
+const IMAGE_QUALITY = 0.75
+
+/** 
+ * Target compressed image size in bytes (~300KB).
+ * WebSocket limit is 512KB, and base64 encoding adds ~33% overhead.
+ */
+const TARGET_IMAGE_SIZE = 300 * 1024
+
+/** Supported image MIME types */
+const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+
+/** File extensions accepted by the file input */
+const ACCEPTED_EXTENSIONS = '.png,.jpg,.jpeg,.gif,.webp'
+
+/**
+ * Represents an image attachment ready to be sent with a message.
+ */
+export type AttachmentFile = {
+  /** Unique identifier for the attachment */
+  id: string
+  /** Original file reference */
+  file: File
+  /** Object URL for image preview */
+  preview: string | null
+  /** Attachment type (always 'image') */
+  type: 'image'
+  /** Base64-encoded image content (without data URL prefix) */
+  base64: string | null
+  /** Error message if processing failed */
+  error?: string
+}
+
+type AttachmentButtonProps = {
+  /** Callback when a file is selected */
+  onFileSelect: (file: AttachmentFile) => void
+  /** Whether the button is disabled */
+  disabled?: boolean
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * Checks if Canvas API is available in the current environment.
+ */
+function isCanvasSupported(): boolean {
+  if (typeof document === 'undefined') return false
+  try {
+    const canvas = document.createElement('canvas')
+    return Boolean(canvas.getContext && canvas.getContext('2d'))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Compresses and resizes an image using the Canvas API.
+ * 
+ * - Resizes images larger than MAX_IMAGE_DIMENSION
+ * - Converts to JPEG (except PNG which may have transparency)
+ * - Progressively reduces quality until under TARGET_IMAGE_SIZE
+ * 
+ * @param file - Image file to compress
+ * @returns Base64-encoded compressed image (without data URL prefix)
+ * @throws Error if canvas is unavailable or image fails to load
+ */
+async function compressImage(file: File): Promise<string> {
+  if (!isCanvasSupported()) {
+    throw new Error('Image compression not available in this browser')
+  }
+
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    const objectUrl = URL.createObjectURL(file)
+
+    const cleanup = () => {
+      URL.revokeObjectURL(objectUrl)
+    }
+
+    img.onload = () => {
+      try {
+        // Calculate new dimensions maintaining aspect ratio
+        let width = img.width
+        let height = img.height
+        
+        if (width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION) {
+          if (width > height) {
+            height = Math.round((height * MAX_IMAGE_DIMENSION) / width)
+            width = MAX_IMAGE_DIMENSION
+          } else {
+            width = Math.round((width * MAX_IMAGE_DIMENSION) / height)
+            height = MAX_IMAGE_DIMENSION
+          }
+        }
+
+        // Create canvas and draw resized image
+        const canvas = document.createElement('canvas')
+        canvas.width = width
+        canvas.height = height
+        
+        const ctx = canvas.getContext('2d')
+        if (!ctx) {
+          cleanup()
+          reject(new Error('Failed to get canvas context'))
+          return
+        }
+        
+        ctx.drawImage(img, 0, 0, width, height)
+        
+        // Use PNG for images that might have transparency, JPEG otherwise
+        const outputType = file.type === 'image/png' ? 'image/png' : 'image/jpeg'
+        let quality = IMAGE_QUALITY
+        
+        // Progressive quality reduction for JPEG
+        let dataUrl = canvas.toDataURL(outputType, quality)
+        
+        if (outputType === 'image/jpeg') {
+          const targetDataUrlSize = TARGET_IMAGE_SIZE * 1.37
+          while (dataUrl.length > targetDataUrlSize && quality > 0.3) {
+            quality -= 0.1
+            dataUrl = canvas.toDataURL(outputType, quality)
+          }
+        }
+        
+        // Extract base64 from data URL
+        const base64 = dataUrl.split(',')[1]
+        if (!base64) {
+          cleanup()
+          reject(new Error('Failed to encode image'))
+          return
+        }
+
+        cleanup()
+        resolve(base64)
+      } catch (err) {
+        cleanup()
+        reject(err instanceof Error ? err : new Error('Image compression failed'))
+      }
+    }
+    
+    img.onerror = () => {
+      cleanup()
+      reject(new Error('Failed to load image'))
+    }
+    
+    img.src = objectUrl
+  })
+}
+
+/**
+ * Checks if a file is a supported image type.
+ */
+function isAcceptedImage(file: File): boolean {
+  return ACCEPTED_IMAGE_TYPES.includes(file.type)
+}
+
+/**
+ * Button component for attaching images to messages.
+ * 
+ * Features:
+ * - Accepts PNG, JPG, GIF, WebP images
+ * - Automatically compresses and resizes large images
+ * - Generates preview URLs for selected images
+ * - Handles errors gracefully with user-friendly messages
+ */
+export function AttachmentButton({
+  onFileSelect,
+  disabled = false,
+  className,
+}: AttachmentButtonProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleClick = useCallback(() => {
+    inputRef.current?.click()
+  }, [])
+
+  const handleFileChange = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0]
+      if (!file) return
+
+      // Reset input to allow selecting the same file again
+      event.target.value = ''
+
+      const id = crypto.randomUUID()
+
+      // Validate file type
+      if (!isAcceptedImage(file)) {
+        onFileSelect({
+          id,
+          file,
+          preview: null,
+          type: 'image',
+          base64: null,
+          error: 'Unsupported file type. Please use PNG, JPG, GIF, or WebP images.',
+        })
+        return
+      }
+
+      // Validate file size
+      if (file.size > MAX_FILE_SIZE) {
+        onFileSelect({
+          id,
+          file,
+          preview: null,
+          type: 'image',
+          base64: null,
+          error: 'Image is too large. Maximum size is 10MB.',
+        })
+        return
+      }
+
+      try {
+        const base64 = await compressImage(file)
+        const preview = URL.createObjectURL(file)
+
+        onFileSelect({
+          id,
+          file,
+          preview,
+          type: 'image',
+          base64,
+        })
+      } catch (err) {
+        onFileSelect({
+          id,
+          file,
+          preview: null,
+          type: 'image',
+          base64: null,
+          error: err instanceof Error ? err.message : 'Failed to process image',
+        })
+      }
+    },
+    [onFileSelect],
+  )
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={ACCEPTED_EXTENSIONS}
+        onChange={handleFileChange}
+        className="hidden"
+        aria-hidden="true"
+      />
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={handleClick}
+        disabled={disabled}
+        className={className}
+        aria-label="Attach image"
+        type="button"
+      >
+        <HugeiconsIcon icon={Attachment01Icon} size={18} strokeWidth={1.8} />
+      </Button>
+    </>
+  )
+}

--- a/apps/webclaw/src/components/attachment-preview.tsx
+++ b/apps/webclaw/src/components/attachment-preview.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useEffect } from 'react'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Cancel01Icon, File01Icon } from '@hugeicons/core-free-icons'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { AttachmentFile } from './attachment-button'
+
+type AttachmentPreviewProps = {
+  attachment: AttachmentFile
+  onRemove: (id: string) => void
+  className?: string
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function getFileExtension(filename: string): string {
+  const parts = filename.split('.')
+  return parts.length > 1 ? parts.pop()?.toUpperCase() || '' : ''
+}
+
+export function AttachmentPreview({
+  attachment,
+  onRemove,
+  className,
+}: AttachmentPreviewProps) {
+  // Cleanup object URL on unmount
+  useEffect(() => {
+    return () => {
+      if (attachment.preview) {
+        URL.revokeObjectURL(attachment.preview)
+      }
+    }
+  }, [attachment.preview])
+
+  const hasError = Boolean(attachment.error)
+
+  return (
+    <div
+      className={cn(
+        'relative flex items-center gap-3 rounded-xl border p-2 pr-3',
+        hasError
+          ? 'border-red-300 bg-red-50'
+          : 'border-primary-200 bg-primary-50',
+        className,
+      )}
+    >
+      {/* Preview thumbnail or file icon */}
+      <div className="relative shrink-0">
+        {attachment.type === 'image' && attachment.preview ? (
+          <img
+            src={attachment.preview}
+            alt={attachment.file.name}
+            className="h-12 w-12 rounded-lg object-cover"
+          />
+        ) : (
+          <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary-100">
+            <HugeiconsIcon
+              icon={File01Icon}
+              size={24}
+              className="text-primary-500"
+            />
+          </div>
+        )}
+      </div>
+
+      {/* File info */}
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-primary-900">
+          {attachment.file.name}
+        </p>
+        {hasError ? (
+          <p className="text-xs text-red-600">{attachment.error}</p>
+        ) : (
+          <p className="text-xs text-primary-500">
+            {getFileExtension(attachment.file.name)} •{' '}
+            {formatFileSize(attachment.file.size)}
+          </p>
+        )}
+      </div>
+
+      {/* Remove button */}
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={() => onRemove(attachment.id)}
+        className="h-6 w-6 shrink-0 rounded-full hover:bg-primary-200"
+        aria-label="Remove attachment"
+        type="button"
+      >
+        <HugeiconsIcon icon={Cancel01Icon} size={14} />
+      </Button>
+    </div>
+  )
+}
+
+type AttachmentPreviewListProps = {
+  attachments: AttachmentFile[]
+  onRemove: (id: string) => void
+  className?: string
+}
+
+export function AttachmentPreviewList({
+  attachments,
+  onRemove,
+  className,
+}: AttachmentPreviewListProps) {
+  if (attachments.length === 0) return null
+
+  return (
+    <div className={cn('flex flex-col gap-2 px-4', className)}>
+      {attachments.map((attachment) => (
+        <AttachmentPreview
+          key={attachment.id}
+          attachment={attachment}
+          onRemove={onRemove}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/webclaw/src/routes/api/send.ts
+++ b/apps/webclaw/src/routes/api/send.ts
@@ -26,7 +26,18 @@ export const Route = createFileRoute('/api/send')({
           const thinking =
             typeof body.thinking === 'string' ? body.thinking : undefined
 
-          if (!message.trim()) {
+          const rawAttachments = body.attachments
+          const attachments = Array.isArray(rawAttachments)
+            ? rawAttachments.filter(
+                (a: unknown): a is { mimeType: string; content: string } =>
+                  typeof a === 'object' &&
+                  a !== null &&
+                  typeof (a as Record<string, unknown>).mimeType === 'string' &&
+                  typeof (a as Record<string, unknown>).content === 'string',
+              )
+            : undefined
+
+          if (!message.trim() && (!attachments || attachments.length === 0)) {
             return json(
               { ok: false, error: 'message required' },
               { status: 400 },
@@ -63,6 +74,7 @@ export const Route = createFileRoute('/api/send')({
             sessionKey,
             message,
             thinking,
+            attachments,
             deliver: false,
             timeoutMs: 120_000,
             idempotencyKey:

--- a/apps/webclaw/src/screens/chat/chat-screen-utils.ts
+++ b/apps/webclaw/src/screens/chat/chat-screen-utils.ts
@@ -1,4 +1,5 @@
 import type { GatewayMessage } from './types'
+import type { AttachmentFile } from '@/components/attachment-button'
 
 type OptimisticMessagePayload = {
   clientId: string
@@ -8,13 +9,42 @@ type OptimisticMessagePayload = {
 
 export function createOptimisticMessage(
   body: string,
+  attachments?: AttachmentFile[],
 ): OptimisticMessagePayload {
   const clientId = crypto.randomUUID()
   const optimisticId = `opt-${clientId}`
   const timestamp = Date.now()
+
+  const content: Array<{
+    type: string
+    text?: string
+    source?: { type: string; media_type: string; data: string }
+  }> = []
+
+  if (attachments && attachments.length > 0) {
+    for (const att of attachments) {
+      if (att.type === 'image' && att.base64) {
+        content.push({
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: att.file.type,
+            data: att.base64,
+          },
+        })
+      }
+    }
+  }
+
+  if (body.trim()) {
+    content.push({ type: 'text', text: body })
+  } else if (attachments && attachments.length > 0) {
+    content.push({ type: 'text', text: '' })
+  }
+
   const optimisticMessage: GatewayMessage = {
     role: 'user',
-    content: [{ type: 'text', text: body }],
+    content: content as GatewayMessage['content'],
     __optimisticId: optimisticId,
     clientId,
     status: 'sending',

--- a/apps/webclaw/src/screens/chat/components/chat-composer.tsx
+++ b/apps/webclaw/src/screens/chat/components/chat-composer.tsx
@@ -10,6 +10,8 @@ import {
   PromptInputTextarea,
 } from '@/components/prompt-kit/prompt-input'
 import { Button } from '@/components/ui/button'
+import { AttachmentButton, type AttachmentFile } from '@/components/attachment-button'
+import { AttachmentPreviewList } from '@/components/attachment-preview'
 
 type ChatComposerProps = {
   onSubmit: (value: string, helpers: ChatComposerHelpers) => void
@@ -21,6 +23,7 @@ type ChatComposerProps = {
 type ChatComposerHelpers = {
   reset: () => void
   setValue: (value: string) => void
+  attachments?: AttachmentFile[]
 }
 
 function ChatComposerComponent({
@@ -30,6 +33,7 @@ function ChatComposerComponent({
   wrapperRef,
 }: ChatComposerProps) {
   const [value, setValue] = useState('')
+  const [attachments, setAttachments] = useState<AttachmentFile[]>([])
   const promptRef = useRef<HTMLTextAreaElement | null>(null)
   const focusPrompt = useCallback(() => {
     if (typeof window === 'undefined') return
@@ -39,8 +43,15 @@ function ChatComposerComponent({
   }, [])
   const reset = useCallback(() => {
     setValue('')
+    setAttachments([])
     focusPrompt()
   }, [focusPrompt])
+  const handleFileSelect = useCallback((file: AttachmentFile) => {
+    setAttachments((prev) => [...prev, file])
+  }, [])
+  const handleRemoveAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id))
+  }, [])
   const setComposerValue = useCallback(
     (nextValue: string) => {
       setValue(nextValue)
@@ -51,11 +62,14 @@ function ChatComposerComponent({
   const handleSubmit = useCallback(() => {
     if (disabled) return
     const body = value.trim()
-    if (body.length === 0) return
-    onSubmit(body, { reset, setValue: setComposerValue })
+    // Allow submit if there's text OR valid attachments
+    const validAttachments = attachments.filter((a) => !a.error && a.base64)
+    if (body.length === 0 && validAttachments.length === 0) return
+    onSubmit(body, { reset, setValue: setComposerValue, attachments: validAttachments })
     focusPrompt()
-  }, [disabled, focusPrompt, onSubmit, reset, setComposerValue, value])
-  const submitDisabled = disabled || value.trim().length === 0
+  }, [disabled, focusPrompt, onSubmit, reset, setComposerValue, value, attachments])
+  const validAttachments = attachments.filter((a) => !a.error && a.base64)
+  const submitDisabled = disabled || (value.trim().length === 0 && validAttachments.length === 0)
 
   return (
     <div
@@ -69,22 +83,34 @@ function ChatComposerComponent({
         isLoading={isLoading}
         disabled={disabled}
       >
+        <AttachmentPreviewList
+          attachments={attachments}
+          onRemove={handleRemoveAttachment}
+        />
         <PromptInputTextarea
           placeholder="Type a message…"
           inputRef={promptRef}
         />
         <PromptInputActions className="justify-end px-3">
-          <PromptInputAction tooltip="Send message">
-            <Button
-              onClick={handleSubmit}
-              disabled={submitDisabled}
-              size="icon-sm"
-              className="rounded-full"
-              aria-label="Send message"
-            >
-              <HugeiconsIcon icon={ArrowUp02Icon} size={18} strokeWidth={2} />
-            </Button>
-          </PromptInputAction>
+          <div className="flex items-center gap-1">
+            <PromptInputAction tooltip="Attach image">
+              <AttachmentButton
+                onFileSelect={handleFileSelect}
+                disabled={disabled}
+              />
+            </PromptInputAction>
+            <PromptInputAction tooltip="Send message">
+              <Button
+                onClick={handleSubmit}
+                disabled={submitDisabled}
+                size="icon-sm"
+                className="rounded-full"
+                aria-label="Send message"
+              >
+                <HugeiconsIcon icon={ArrowUp02Icon} size={18} strokeWidth={2} />
+              </Button>
+            </PromptInputAction>
+          </div>
         </PromptInputActions>
       </PromptInput>
     </div>

--- a/apps/webclaw/src/screens/chat/components/message-item.tsx
+++ b/apps/webclaw/src/screens/chat/components/message-item.tsx
@@ -129,6 +129,38 @@ function thinkingFromMessage(msg: GatewayMessage): string | null {
   return null
 }
 
+/**
+ * Represents an image attachment in message content.
+ */
+type ImagePart = {
+  type: 'image'
+  source: {
+    type: 'base64'
+    media_type: string
+    data: string
+  }
+}
+
+/**
+ * Extracts image attachments from a gateway message.
+ * @param msg - The gateway message to extract images from
+ * @returns Array of image parts with base64 data
+ */
+function imagesFromMessage(msg: GatewayMessage): ImagePart[] {
+  const parts = Array.isArray(msg.content) ? msg.content : []
+  const images: ImagePart[] = []
+  for (const part of parts) {
+    if (
+      part.type === 'image' &&
+      'source' in part &&
+      typeof (part as ImagePart).source?.data === 'string'
+    ) {
+      images.push(part as ImagePart)
+    }
+  }
+  return images
+}
+
 function MessageItemComponent({
   message,
   toolResultsByCallId,
@@ -141,6 +173,7 @@ function MessageItemComponent({
   const role = message.role || 'assistant'
   const text = textFromMessage(message)
   const thinking = thinkingFromMessage(message)
+  const images = imagesFromMessage(message)
   const isUser = role === 'user'
   const timestamp = getMessageTimestamp(message)
 
@@ -165,6 +198,22 @@ function MessageItemComponent({
       {thinking && settings.showReasoningBlocks && (
         <div className="w-full max-w-[900px]">
           <Thinking content={thinking} />
+        </div>
+      )}
+      {/* Render images if present */}
+      {images.length > 0 && (
+        <div className={cn(
+          'flex flex-wrap gap-2 mb-2',
+          isUser ? 'justify-end' : 'justify-start'
+        )}>
+          {images.map((img, idx) => (
+            <img
+              key={idx}
+              src={`data:${img.source.media_type};base64,${img.source.data}`}
+              alt={`Attachment ${idx + 1}`}
+              className="max-w-[300px] max-h-[300px] rounded-lg object-cover"
+            />
+          ))}
         </div>
       )}
       <Message className={cn(isUser ? 'flex-row-reverse' : '')}>

--- a/apps/webclaw/src/screens/chat/pending-send.ts
+++ b/apps/webclaw/src/screens/chat/pending-send.ts
@@ -1,10 +1,12 @@
 import type { GatewayMessage } from './types'
+import type { AttachmentFile } from '@/components/attachment-button'
 
 export type PendingSendPayload = {
   sessionKey: string
   friendlyId: string
   message: string
   optimisticMessage: GatewayMessage
+  attachments?: AttachmentFile[]
 }
 
 let pendingSend: PendingSendPayload | null = null


### PR DESCRIPTION
## Summary

Adds image attachment support to WebClaw, enabling users to send images to vision-capable AI models.

## Features

- 📎 **AttachmentButton** - File picker in the composer
- 🗜️ **Client-side compression** - Auto-resize & compress images to fit WebSocket limit
- 🖼️ **Preview** - See selected images before sending
- 👁️ **Display** - Render images in chat messages
- 📝 **Image-only messages** - Send images without text

## Technical Details

### Compression Settings (for 512KB WebSocket limit)
- Max dimension: 1280px (width or height)
- JPEG quality: 75% (progressive reduction if needed)
- Target size: ~300KB (→ ~400KB base64 → under 512KB limit)

### Supported Formats
PNG, JPG, GIF, WebP

### Gateway Format
```json
{ "mimeType": "image/png", "content": "<base64>" }
```

## Files Changed

| File | Description |
|------|-------------|
| `attachment-button.tsx` | **NEW** - File selection + compression |
| `attachment-preview.tsx` | **NEW** - Preview list component |
| `chat-composer.tsx` | Attachment state & UI integration |
| `send.ts` | Forward attachments to Gateway |
| `message-item.tsx` | Render images in messages |
| `chat-screen-utils.ts` | Optimistic message with attachments |
| `chat-screen.tsx` | Pass attachments through send flow |
| `pending-send.ts` | Type definition update |

## Screenshots

_Tested in OpenCami fork - working with OpenClaw Gateway_

---

Closes #3