### PR TITLE
feat: add Dockerfile, docker-compose, and Docker documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+.git
+.gitignore
+dist
+.output
+.env
+.env.local
+.env.*.local
+*.md
+!README.md
+.vscode
+.idea
+*.log
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# ---- Stage 1: Install dependencies ----
+FROM node:22-alpine AS deps
+
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/webclaw/package.json ./apps/webclaw/package.json
+# Include landing package.json so pnpm workspace resolution succeeds
+COPY apps/landing/package.json ./apps/landing/package.json
+
+RUN pnpm install --frozen-lockfile
+
+# ---- Stage 2: Build the app ----
+FROM node:22-alpine AS build
+
+RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/webclaw/node_modules ./apps/webclaw/node_modules
+COPY --from=deps /app/apps/landing/node_modules ./apps/landing/node_modules
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/webclaw ./apps/webclaw
+COPY apps/landing/package.json ./apps/landing/package.json
+
+RUN pnpm build
+
+# ---- Stage 3: Production runtime ----
+FROM node:22-alpine AS runtime
+
+WORKDIR /app
+
+# Copy the Nitro server output (TanStack Start builds to .output/)
+COPY --from=build /app/apps/webclaw/.output ./.output
+
+ENV NODE_ENV=production
+ENV CLAWDBOT_GATEWAY_URL=ws://host.docker.internal:18789
+ENV CLAWDBOT_GATEWAY_TOKEN=
+ENV CLAWDBOT_GATEWAY_PASSWORD=
+
+EXPOSE 3000
+
+CMD ["node", ".output/server/index.mjs"]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,19 @@ Default URL is `ws://127.0.0.1:18789`. Docs: https://docs.openclaw.ai/gateway
 pnpm install
 pnpm dev
 ```
+
+## Docker
+
+```bash
+# Build and run
+docker compose up --build
+
+# Or build manually
+docker build -t webclaw .
+docker run -p 3000:3000 \
+  -e CLAWDBOT_GATEWAY_URL=ws://host.docker.internal:18789 \
+  -e CLAWDBOT_GATEWAY_TOKEN=your_token \
+  webclaw
+```
+
+Note: Use `host.docker.internal` instead of `127.0.0.1` to connect to a gateway running on your host machine.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  webclaw:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - CLAWDBOT_GATEWAY_URL=${CLAWDBOT_GATEWAY_URL:-ws://host.docker.internal:18789}
+      - CLAWDBOT_GATEWAY_TOKEN=${CLAWDBOT_GATEWAY_TOKEN:-}
+      - CLAWDBOT_GATEWAY_PASSWORD=${CLAWDBOT_GATEWAY_PASSWORD:-}
+    restart: unless-stopped


### PR DESCRIPTION
Closes #7

## What's included

### 1. Multi-stage Dockerfile
- **Stage 1 (deps):** `node:22-alpine`, installs pnpm via corepack, copies workspace manifests, runs `pnpm install --frozen-lockfile`
- **Stage 2 (build):** Copies source code, runs `pnpm build` (builds only `apps/webclaw` via the root script)
- **Stage 3 (runtime):** Clean `node:22-alpine` with only the Nitro `.output/` server bundle — minimal image size

### 2. docker-compose.yml
- Webclaw service with port mapping `3000:3000`
- Environment variables sourced from `.env` with sensible defaults
- `restart: unless-stopped` policy

### 3. .dockerignore
- Excludes `node_modules`, `.git`, `dist`, `.output`, env files, IDE configs, etc.

### 4. README update
- Added a **Docker** section after the existing **Setup** section
- Documents both `docker compose up --build` and manual `docker build`/`docker run`
- Includes `host.docker.internal` hint for connecting to a host-side gateway

### Key design decisions
- **pnpm workspace-aware:** Copies both `apps/webclaw/package.json` and `apps/landing/package.json` so workspace resolution succeeds, but only builds webclaw
- **Corepack for pnpm:** Uses `corepack prepare pnpm@9.15.4` matching the repo's `packageManager` field
- **Minimal runtime:** Final stage contains only the self-contained Nitro server output — no `node_modules`, no source code
- **Environment variables:** `CLAWDBOT_GATEWAY_URL`, `CLAWDBOT_GATEWAY_TOKEN`, `CLAWDBOT_GATEWAY_PASSWORD` configurable at runtime