### PR TITLE
feat: add conversation export (Markdown, JSON, Plain Text)

### DIFF
--- a/apps/webclaw/src/lib/export-conversation.ts
+++ b/apps/webclaw/src/lib/export-conversation.ts
@@ -1,0 +1,140 @@
+import type { GatewayMessage } from '@/screens/chat/types'
+import { textFromMessage, getMessageTimestamp } from '@/screens/chat/utils'
+
+function formatDate(date: Date): string {
+  return date.toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function roleLabel(role: string | undefined): string {
+  switch (role) {
+    case 'user':
+      return 'User'
+    case 'assistant':
+      return 'Assistant'
+    default:
+      return role ?? 'Unknown'
+  }
+}
+
+function isExportableMessage(msg: GatewayMessage): boolean {
+  return msg.role === 'user' || msg.role === 'assistant'
+}
+
+function sanitizeFilename(title: string): string {
+  return title
+    .replace(/[^a-zA-Z0-9\s_-]/g, '')
+    .replace(/\s+/g, '-')
+    .toLowerCase()
+    .slice(0, 64)
+}
+
+export function exportAsMarkdown(
+  messages: GatewayMessage[],
+  title: string,
+): string {
+  const now = formatDate(new Date())
+  const lines: string[] = [`# Chat: ${title}`, `*Exported on ${now}*`, '']
+
+  for (const msg of messages) {
+    if (!isExportableMessage(msg)) continue
+    const content = textFromMessage(msg)
+    if (!content) continue
+    lines.push(`## ${roleLabel(msg.role)}`, '', content, '')
+  }
+
+  return lines.join('\n')
+}
+
+export function exportAsJson(
+  messages: GatewayMessage[],
+  title: string,
+): string {
+  const exportedAt = new Date().toISOString()
+  const exportMessages = messages
+    .filter(isExportableMessage)
+    .map((msg) => {
+      const ts = getMessageTimestamp(msg)
+      const d = new Date(ts)
+      const isoTime = Number.isNaN(d.getTime()) ? 'unknown' : d.toISOString()
+      return {
+        role: msg.role ?? 'unknown',
+        content: textFromMessage(msg),
+        timestamp: isoTime,
+      }
+    })
+    .filter((m) => m.content.length > 0)
+
+  return JSON.stringify(
+    { title, exportedAt, messages: exportMessages },
+    null,
+    2,
+  )
+}
+
+export function exportAsText(
+  messages: GatewayMessage[],
+  title: string,
+): string {
+  const now = formatDate(new Date())
+  const lines: string[] = [`Chat: ${title}`, `Exported on ${now}`, '']
+
+  for (const msg of messages) {
+    if (!isExportableMessage(msg)) continue
+    const content = textFromMessage(msg)
+    if (!content) continue
+    lines.push(`${roleLabel(msg.role)}: ${content}`, '')
+  }
+
+  return lines.join('\n')
+}
+
+export function downloadFile(
+  content: string,
+  filename: string,
+  mimeType: string,
+): void {
+  if (typeof document === 'undefined') return
+  const blob = new Blob([content], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+export type ExportFormat = 'markdown' | 'json' | 'text'
+
+export function exportConversation(
+  messages: GatewayMessage[],
+  title: string,
+  format: ExportFormat,
+): void {
+  const safeName = sanitizeFilename(title) || 'chat-export'
+
+  switch (format) {
+    case 'markdown': {
+      const content = exportAsMarkdown(messages, title)
+      downloadFile(content, `${safeName}.md`, 'text/markdown')
+      break
+    }
+    case 'json': {
+      const content = exportAsJson(messages, title)
+      downloadFile(content, `${safeName}.json`, 'application/json')
+      break
+    }
+    case 'text': {
+      const content = exportAsText(messages, title)
+      downloadFile(content, `${safeName}.txt`, 'text/plain')
+      break
+    }
+  }
+}

--- a/apps/webclaw/src/screens/chat/chat-screen.tsx
+++ b/apps/webclaw/src/screens/chat/chat-screen.tsx
@@ -622,6 +622,7 @@ export function ChatScreen({
             onOpenSidebar={handleOpenSidebar}
             usedTokens={activeSession?.totalTokens}
             maxTokens={activeSession?.contextTokens}
+            messages={displayMessages}
           />
 
           {hideUi ? null : (

--- a/apps/webclaw/src/screens/chat/components/chat-header.tsx
+++ b/apps/webclaw/src/screens/chat/components/chat-header.tsx
@@ -1,8 +1,19 @@
-import { memo } from 'react'
+import { memo, useCallback } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Menu01Icon } from '@hugeicons/core-free-icons'
+import { Menu01Icon, Download04Icon } from '@hugeicons/core-free-icons'
 import { Button } from '@/components/ui/button'
+import {
+  MenuRoot,
+  MenuTrigger,
+  MenuContent,
+  MenuItem,
+} from '@/components/ui/menu'
 import { ContextMeter } from './context-meter'
+import {
+  exportConversation,
+  type ExportFormat,
+} from '@/lib/export-conversation'
+import type { GatewayMessage } from '../types'
 
 type ChatHeaderProps = {
   activeTitle: string
@@ -11,6 +22,7 @@ type ChatHeaderProps = {
   onOpenSidebar?: () => void
   usedTokens?: number
   maxTokens?: number
+  messages?: GatewayMessage[]
 }
 
 function ChatHeaderComponent({
@@ -20,7 +32,18 @@ function ChatHeaderComponent({
   onOpenSidebar,
   usedTokens,
   maxTokens,
+  messages,
 }: ChatHeaderProps) {
+  const handleExport = useCallback(
+    (format: ExportFormat) => {
+      if (!messages || messages.length === 0) return
+      exportConversation(messages, activeTitle, format)
+    },
+    [messages, activeTitle],
+  )
+
+  const hasMessages = messages && messages.length > 0
+
   return (
     <div
       ref={wrapperRef}
@@ -38,7 +61,40 @@ function ChatHeaderComponent({
         </Button>
       ) : null}
       <div className="text-sm font-medium truncate">{activeTitle}</div>
-      <ContextMeter usedTokens={usedTokens} maxTokens={maxTokens} />
+      <div className="flex items-center gap-1">
+        {hasMessages ? (
+          <MenuRoot>
+            <MenuTrigger
+              render={
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  className="text-primary-800 hover:bg-primary-100"
+                  aria-label="Export conversation"
+                />
+              }
+            >
+              <HugeiconsIcon
+                icon={Download04Icon}
+                size={16}
+                strokeWidth={1.6}
+              />
+            </MenuTrigger>
+            <MenuContent side="bottom" align="end">
+              <MenuItem onClick={() => handleExport('markdown')}>
+                Markdown (.md)
+              </MenuItem>
+              <MenuItem onClick={() => handleExport('json')}>
+                JSON (.json)
+              </MenuItem>
+              <MenuItem onClick={() => handleExport('text')}>
+                Plain Text (.txt)
+              </MenuItem>
+            </MenuContent>
+          </MenuRoot>
+        ) : null}
+        <ContextMeter usedTokens={usedTokens} maxTokens={maxTokens} />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Conversation Export

Adds the ability to export chat conversations in three formats: **Markdown**, **JSON**, and **Plain Text**.

### Changes

#### New file: `apps/webclaw/src/lib/export-conversation.ts`
- `exportAsMarkdown()` — Formats conversation as Markdown with headers, preserves code blocks, skips tool messages
- `exportAsJson()` — Structured JSON export with title, timestamp, and message array
- `exportAsText()` — Clean plain text format
- `downloadFile()` — Browser download helper using Blob + temporary anchor element
- `exportConversation()` — Convenience wrapper that picks format and triggers download

#### Modified: `apps/webclaw/src/screens/chat/components/chat-header.tsx`
- Added download icon button (using `Download04Icon` from `@hugeicons/core-free-icons`)
- Dropdown menu with three export options using the existing `Menu` UI component
- Button only appears when the conversation has messages
- Wrapped title and right-side actions in a flex layout for proper alignment

#### Modified: `apps/webclaw/src/screens/chat/chat-screen.tsx`
- Passes `displayMessages` to `ChatHeader` via new `messages` prop

### Design Decisions
- Reuses existing `textFromMessage` and `getMessageTimestamp` utilities from `chat/utils.ts`
- Follows project conventions: `@hugeicons/react` icons, Tailwind classes, `memo` wrapping
- Uses the existing `MenuRoot/MenuTrigger/MenuContent/MenuItem` component from `@/components/ui/menu`
- Filenames are sanitized (alphanumeric + hyphens, max 64 chars)
- Tool messages and thinking blocks are filtered out of exports