### PR TITLE
feat: add pin/unpin sessions to sidebar

### DIFF
--- a/apps/webclaw/src/screens/chat/components/sidebar/session-item.tsx
+++ b/apps/webclaw/src/screens/chat/components/sidebar/session-item.tsx
@@ -6,6 +6,8 @@ import {
   MoreHorizontalIcon,
   Pen01Icon,
   Delete01Icon,
+  PinIcon,
+  PinOffIcon,
 } from '@hugeicons/core-free-icons'
 import { cn } from '@/lib/utils'
 import {
@@ -20,17 +22,21 @@ import type { SessionMeta } from '../../types'
 type SessionItemProps = {
   session: SessionMeta
   active: boolean
+  pinned?: boolean
   onSelect?: () => void
   onRename: (session: SessionMeta) => void
   onDelete: (session: SessionMeta) => void
+  onTogglePin?: (sessionKey: string) => void
 }
 
 function SessionItemComponent({
   session,
   active,
+  pinned = false,
   onSelect,
   onRename,
   onDelete,
+  onTogglePin,
 }: SessionItemProps) {
   const label =
     session.label || session.title || session.derivedTitle || session.friendlyId
@@ -49,7 +55,15 @@ function SessionItemComponent({
           : 'bg-transparent text-primary-950 [&:hover:not(:has(button:hover))]:bg-primary-200',
       )}
     >
-      <div className="flex-1 min-w-0">
+      <div className="flex-1 min-w-0 flex items-center gap-1">
+        {pinned && (
+          <HugeiconsIcon
+            icon={PinIcon}
+            size={12}
+            strokeWidth={1.5}
+            className="shrink-0 text-primary-400"
+          />
+        )}
         <div className="text-sm font-[450] line-clamp-1">{label}</div>
       </div>
       <MenuRoot>
@@ -72,6 +86,23 @@ function SessionItemComponent({
           />
         </MenuTrigger>
         <MenuContent side="bottom" align="end">
+          {onTogglePin && (
+            <MenuItem
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                onTogglePin(session.key)
+              }}
+              className="gap-2"
+            >
+              <HugeiconsIcon
+                icon={pinned ? PinOffIcon : PinIcon}
+                size={20}
+                strokeWidth={1.5}
+              />{' '}
+              {pinned ? 'Unpin' : 'Pin'}
+            </MenuItem>
+          )}
           <MenuItem
             onClick={(event) => {
               event.preventDefault()
@@ -102,9 +133,11 @@ function SessionItemComponent({
 
 function areSessionItemsEqual(prev: SessionItemProps, next: SessionItemProps) {
   if (prev.active !== next.active) return false
+  if (prev.pinned !== next.pinned) return false
   if (prev.onSelect !== next.onSelect) return false
   if (prev.onRename !== next.onRename) return false
   if (prev.onDelete !== next.onDelete) return false
+  if (prev.onTogglePin !== next.onTogglePin) return false
   if (prev.session === next.session) return true
   return (
     prev.session.key === next.session.key &&

--- a/apps/webclaw/src/screens/chat/hooks/use-pinned-sessions.ts
+++ b/apps/webclaw/src/screens/chat/hooks/use-pinned-sessions.ts
@@ -1,0 +1,60 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+type PinnedSessionsState = {
+  pinnedSessionKeys: string[]
+  pin: (sessionKey: string) => void
+  unpin: (sessionKey: string) => void
+  isPinned: (sessionKey: string) => boolean
+  toggle: (sessionKey: string) => void
+}
+
+export const usePinnedSessionsStore = create<PinnedSessionsState>()(
+  persist(
+    (set, get) => ({
+      pinnedSessionKeys: [],
+      pin: (sessionKey: string) =>
+        set((state) => {
+          if (state.pinnedSessionKeys.includes(sessionKey)) return state
+          return { pinnedSessionKeys: [...state.pinnedSessionKeys, sessionKey] }
+        }),
+      unpin: (sessionKey: string) =>
+        set((state) => ({
+          pinnedSessionKeys: state.pinnedSessionKeys.filter(
+            (key) => key !== sessionKey,
+          ),
+        })),
+      isPinned: (sessionKey: string) =>
+        get().pinnedSessionKeys.includes(sessionKey),
+      toggle: (sessionKey: string) => {
+        const { pinnedSessionKeys } = get()
+        if (pinnedSessionKeys.includes(sessionKey)) {
+          set({
+            pinnedSessionKeys: pinnedSessionKeys.filter(
+              (key) => key !== sessionKey,
+            ),
+          })
+        } else {
+          set({ pinnedSessionKeys: [...pinnedSessionKeys, sessionKey] })
+        }
+      },
+    }),
+    {
+      name: 'pinned-sessions',
+    },
+  ),
+)
+
+export function usePinnedSessions() {
+  const pinnedSessionKeys = usePinnedSessionsStore(
+    (state) => state.pinnedSessionKeys,
+  )
+  const pin = usePinnedSessionsStore((state) => state.pin)
+  const unpin = usePinnedSessionsStore((state) => state.unpin)
+  const toggle = usePinnedSessionsStore((state) => state.toggle)
+
+  const isPinned = (sessionKey: string) =>
+    pinnedSessionKeys.includes(sessionKey)
+
+  return { pinnedSessionKeys, pin, unpin, isPinned, toggle }
+}


### PR DESCRIPTION
## Summary

Add the ability to pin important sessions to the top of the sidebar for quick access.

### Changes

**New file: `use-pinned-sessions.ts`**
- Zustand store with localStorage persistence (matches existing `use-chat-settings` pattern)
- Stores an array of pinned session keys
- Exposes `pin()`, `unpin()`, `isPinned()`, and `toggle()` functions

**Modified: `sidebar-sessions.tsx`**
- Splits sessions into two groups: pinned (top) and unpinned (bottom)
- Adds a subtle "Pinned" section header with a pin icon when pinned sessions exist
- Thin divider separates pinned from unpinned sessions

**Modified: `session-item.tsx`**
- Adds "Pin" / "Unpin" option to the existing three-dot context menu (with PinIcon/PinOffIcon)
- Pinned sessions show a small pin icon next to the title
- Updated memo equality check to include `pinned` and `onTogglePin` props

### Design decisions
- Uses `PinIcon` and `PinOffIcon` from `@hugeicons/core-free-icons` (consistent with existing icon usage)
- Pin state persists across page reloads via localStorage
- Visual indicators are intentionally subtle to avoid cluttering the sidebar
- Pinned sessions maintain their original sort order within the pinned group

Closes #14