### PR TITLE
feat: add conversation search (⌘F current, ⌘⇧F global)

### DIFF
--- a/apps/webclaw/src/routes/api/search.ts
+++ b/apps/webclaw/src/routes/api/search.ts
@@ -1,0 +1,144 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { gatewayRpc } from '../../server/gateway'
+
+type SessionListResponse = {
+  sessions?: Array<{
+    key?: string
+    friendlyId?: string
+    title?: string
+    derivedTitle?: string
+    label?: string
+  }>
+}
+
+type ChatHistoryResponse = {
+  sessionKey: string
+  messages: Array<{
+    role?: string
+    content?: Array<{ type?: string; text?: string }>
+  }>
+}
+
+function textFromContent(
+  content: Array<{ type?: string; text?: string }> | undefined,
+): string {
+  if (!Array.isArray(content)) return ''
+  return content
+    .map((part) => (part.type === 'text' ? String(part.text ?? '') : ''))
+    .join('')
+    .trim()
+}
+
+export const Route = createFileRoute('/api/search')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        try {
+          const url = new URL(request.url)
+          const query = url.searchParams.get('q')?.trim() ?? ''
+          const sessionKey = url.searchParams.get('sessionKey')?.trim()
+
+          if (!query) {
+            return json({ results: [] })
+          }
+
+          const lowerQuery = query.toLowerCase()
+
+          // Single-session search
+          if (sessionKey) {
+            const history = await gatewayRpc<ChatHistoryResponse>(
+              'chat.history',
+              { sessionKey, limit: 500 },
+            )
+            const matches = (history.messages ?? [])
+              .map((msg, index) => ({
+                text: textFromContent(msg.content),
+                role: msg.role ?? 'assistant',
+                index,
+              }))
+              .filter(
+                (m) =>
+                  m.role !== 'toolResult' &&
+                  m.text.toLowerCase().includes(lowerQuery),
+              )
+
+            return json({
+              results: [
+                {
+                  sessionKey,
+                  sessionTitle: sessionKey,
+                  friendlyId: sessionKey,
+                  messages: matches,
+                },
+              ],
+            })
+          }
+
+          // Global search: iterate all sessions
+          const sessionsData = await gatewayRpc<SessionListResponse>(
+            'sessions.list',
+            {},
+          )
+          const sessions = sessionsData.sessions ?? []
+
+          const results: Array<{
+            sessionKey: string
+            sessionTitle: string
+            friendlyId: string
+            messages: Array<{ text: string; role: string; index: number }>
+          }> = []
+
+          // Search up to 20 sessions to avoid timeouts
+          const searchSessions = sessions.slice(0, 20)
+
+          for (const session of searchSessions) {
+            const key = session.key ?? session.friendlyId ?? ''
+            if (!key) continue
+            try {
+              const history = await gatewayRpc<ChatHistoryResponse>(
+                'chat.history',
+                { sessionKey: key, limit: 200 },
+              )
+              const matches = (history.messages ?? [])
+                .map((msg, index) => ({
+                  text: textFromContent(msg.content),
+                  role: msg.role ?? 'assistant',
+                  index,
+                }))
+                .filter(
+                  (m) =>
+                    m.role !== 'toolResult' &&
+                    m.text.toLowerCase().includes(lowerQuery),
+                )
+
+              if (matches.length > 0) {
+                results.push({
+                  sessionKey: key,
+                  sessionTitle:
+                    session.title ??
+                    session.derivedTitle ??
+                    session.label ??
+                    key,
+                  friendlyId: session.friendlyId ?? key,
+                  messages: matches.slice(0, 10), // limit per session
+                })
+              }
+            } catch {
+              // skip sessions that fail to load
+            }
+          }
+
+          return json({ results })
+        } catch (err) {
+          return json(
+            {
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/apps/webclaw/src/screens/chat/chat-screen.tsx
+++ b/apps/webclaw/src/screens/chat/chat-screen.tsx
@@ -45,6 +45,8 @@ import {
 import { useChatMeasurements } from './hooks/use-chat-measurements'
 import { useChatHistory } from './hooks/use-chat-history'
 import { useChatMobile } from './hooks/use-chat-mobile'
+import { useChatSearch } from './hooks/use-chat-search'
+import { ChatSearchBar } from './components/chat-search-bar'
 import { useChatSessions } from './hooks/use-chat-sessions'
 import type { ChatComposerHelpers } from './components/chat-composer'
 import type { HistoryResponse } from './types'
@@ -113,6 +115,8 @@ export function ChatScreen({
     sessionsReady: sessionsQuery.isSuccess,
     queryClient,
   })
+
+  const chatSearch = useChatSearch(displayMessages)
 
   const uiQuery = useQuery({
     queryKey: chatUiQueryKey,
@@ -624,6 +628,24 @@ export function ChatScreen({
             maxTokens={activeSession?.contextTokens}
           />
 
+          {chatSearch.isOpen && (
+            <ChatSearchBar
+              query={chatSearch.query}
+              scope={chatSearch.scope}
+              resultCount={
+                chatSearch.scope === 'current'
+                  ? chatSearch.results.length
+                  : chatSearch.globalResults.length
+              }
+              activeIndex={chatSearch.activeIndex}
+              onQueryChange={chatSearch.setQuery}
+              onScopeChange={chatSearch.setScope}
+              onNext={chatSearch.goNext}
+              onPrev={chatSearch.goPrev}
+              onClose={chatSearch.close}
+            />
+          )}
+
           {hideUi ? null : (
             <>
               <ChatMessageList
@@ -638,6 +660,17 @@ export function ChatScreen({
                 pinGroupMinHeight={pinGroupMinHeight}
                 headerHeight={headerHeight}
                 contentStyle={stableContentStyle}
+                searchHighlight={
+                  chatSearch.isOpen && chatSearch.query.trim()
+                    ? chatSearch.query
+                    : undefined
+                }
+                searchResults={
+                  chatSearch.isOpen ? chatSearch.results : undefined
+                }
+                searchActiveIndex={
+                  chatSearch.isOpen ? chatSearch.activeIndex : undefined
+                }
               />
               <ChatComposer
                 onSubmit={send}

--- a/apps/webclaw/src/screens/chat/components/chat-search-bar.tsx
+++ b/apps/webclaw/src/screens/chat/components/chat-search-bar.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from 'react'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  Search01Icon,
+  ArrowUp01Icon,
+  ArrowDown01Icon,
+  Cancel01Icon,
+} from '@hugeicons/core-free-icons'
+import { Button } from '@/components/ui/button'
+
+type SearchScope = 'current' | 'global'
+
+type ChatSearchBarProps = {
+  query: string
+  scope: SearchScope
+  resultCount: number
+  activeIndex: number
+  onQueryChange: (query: string) => void
+  onScopeChange: (scope: SearchScope) => void
+  onNext: () => void
+  onPrev: () => void
+  onClose: () => void
+}
+
+export function ChatSearchBar({
+  query,
+  scope,
+  resultCount,
+  activeIndex,
+  onQueryChange,
+  onScopeChange,
+  onNext,
+  onPrev,
+  onClose,
+}: ChatSearchBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  return (
+    <div className="border-b border-primary-200 bg-surface px-4 py-2 flex items-center gap-2">
+      <HugeiconsIcon
+        icon={Search01Icon}
+        size={16}
+        strokeWidth={1.6}
+        className="text-primary-500 shrink-0"
+      />
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        placeholder={
+          scope === 'current' ? 'Search in chat…' : 'Search all chats…'
+        }
+        className="flex-1 bg-transparent text-sm text-primary-900 placeholder:text-primary-400 outline-none min-w-0"
+      />
+
+      {query.trim().length > 0 && (
+        <span className="text-xs text-primary-500 shrink-0">
+          {resultCount > 0
+            ? `${activeIndex + 1} of ${resultCount}`
+            : 'No results'}
+        </span>
+      )}
+
+      <div className="flex items-center gap-0.5 shrink-0">
+        <button
+          type="button"
+          onClick={() =>
+            onScopeChange(scope === 'current' ? 'global' : 'current')
+          }
+          className={`text-xs px-2 py-0.5 rounded transition-colors ${
+            scope === 'global'
+              ? 'bg-primary-200 text-primary-900'
+              : 'text-primary-500 hover:text-primary-700'
+          }`}
+        >
+          {scope === 'current' ? 'This chat' : 'All chats'}
+        </button>
+
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={onPrev}
+          disabled={resultCount === 0}
+          aria-label="Previous result"
+          className="text-primary-600 hover:bg-primary-100"
+        >
+          <HugeiconsIcon icon={ArrowUp01Icon} size={14} strokeWidth={1.6} />
+        </Button>
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={onNext}
+          disabled={resultCount === 0}
+          aria-label="Next result"
+          className="text-primary-600 hover:bg-primary-100"
+        >
+          <HugeiconsIcon icon={ArrowDown01Icon} size={14} strokeWidth={1.6} />
+        </Button>
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          onClick={onClose}
+          aria-label="Close search"
+          className="text-primary-600 hover:bg-primary-100"
+        >
+          <HugeiconsIcon icon={Cancel01Icon} size={14} strokeWidth={1.6} />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/webclaw/src/screens/chat/hooks/use-chat-search.ts
+++ b/apps/webclaw/src/screens/chat/hooks/use-chat-search.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { textFromMessage } from '../utils'
+import type { GatewayMessage } from '../types'
+
+type SearchScope = 'current' | 'global'
+
+type SearchResult = {
+  messageIndex: number
+  sessionKey?: string
+  sessionTitle?: string
+}
+
+type GlobalSearchResult = {
+  sessionKey: string
+  sessionTitle: string
+  friendlyId: string
+  messages: Array<{ text: string; role: string; index: number }>
+}
+
+type UseChatSearchReturn = {
+  isOpen: boolean
+  query: string
+  scope: SearchScope
+  results: Array<SearchResult>
+  activeIndex: number
+  globalResults: Array<GlobalSearchResult>
+  open: (scope?: SearchScope) => void
+  close: () => void
+  setQuery: (query: string) => void
+  setScope: (scope: SearchScope) => void
+  goNext: () => void
+  goPrev: () => void
+}
+
+export function useChatSearch(
+  displayMessages: Array<GatewayMessage>,
+): UseChatSearchReturn {
+  const [isOpen, setIsOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [scope, setScope] = useState<SearchScope>('current')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [globalResults, setGlobalResults] = useState<Array<GlobalSearchResult>>(
+    [],
+  )
+  const debounceRef = useRef<number | null>(null)
+
+  // Current-chat search: filter messages matching query
+  const results = useMemo<Array<SearchResult>>(() => {
+    if (!isOpen || !query.trim() || scope !== 'current') return []
+    const lowerQuery = query.toLowerCase()
+    const matches: Array<SearchResult> = []
+    for (let i = 0; i < displayMessages.length; i++) {
+      const msg = displayMessages[i]
+      if (msg.role === 'toolResult') continue
+      const text = textFromMessage(msg).toLowerCase()
+      if (text.includes(lowerQuery)) {
+        matches.push({ messageIndex: i })
+      }
+    }
+    return matches
+  }, [isOpen, query, scope, displayMessages])
+
+  // Global search with debounce and abort guard
+  useEffect(() => {
+    if (!isOpen || !query.trim() || scope !== 'global') {
+      setGlobalResults([])
+      return
+    }
+    const controller = new AbortController()
+    if (debounceRef.current) window.clearTimeout(debounceRef.current)
+    debounceRef.current = window.setTimeout(() => {
+      fetch(`/api/search?q=${encodeURIComponent(query.trim())}`, {
+        signal: controller.signal,
+      })
+        .then(async (res) => {
+          if (!res.ok) return
+          const data = (await res.json()) as {
+            results?: Array<GlobalSearchResult>
+          }
+          setGlobalResults(data.results ?? [])
+        })
+        .catch(() => {
+          setGlobalResults([])
+        })
+    }, 300)
+    return () => {
+      controller.abort()
+      if (debounceRef.current) window.clearTimeout(debounceRef.current)
+    }
+  }, [isOpen, query, scope])
+
+  // Reset active index when results change
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [results.length, globalResults.length])
+
+  const open = useCallback((newScope: SearchScope = 'current') => {
+    setIsOpen(true)
+    setScope(newScope)
+  }, [])
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+    setQuery('')
+    setActiveIndex(0)
+    setGlobalResults([])
+  }, [])
+
+  const goNext = useCallback(() => {
+    const total = scope === 'current' ? results.length : globalResults.length
+    if (total === 0) return
+    setActiveIndex((prev) => (prev + 1) % total)
+  }, [scope, results.length, globalResults.length])
+
+  const goPrev = useCallback(() => {
+    const total = scope === 'current' ? results.length : globalResults.length
+    if (total === 0) return
+    setActiveIndex((prev) => (prev - 1 + total) % total)
+  }, [scope, results.length, globalResults.length])
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const isMod = e.metaKey || e.ctrlKey
+      if (isMod && e.key === 'f' && !e.shiftKey) {
+        e.preventDefault()
+        open('current')
+      } else if (isMod && e.key === 'f' && e.shiftKey) {
+        e.preventDefault()
+        open('global')
+      } else if (e.key === 'Escape' && isOpen) {
+        e.preventDefault()
+        close()
+      } else if (e.key === 'Enter' && isOpen) {
+        e.preventDefault()
+        if (e.shiftKey) {
+          goPrev()
+        } else {
+          goNext()
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, open, close, goNext, goPrev])
+
+  return {
+    isOpen,
+    query,
+    scope,
+    results,
+    activeIndex,
+    globalResults,
+    open,
+    close,
+    setQuery,
+    setScope,
+    goNext,
+    goPrev,
+  }
+}


### PR DESCRIPTION
## What

Adds in-chat conversation search with keyboard shortcuts.

### Features
- **⌘F** — Search within current chat (client-side, instant)
- **⌘⇧F** — Search across all chats (server-side via new API endpoint)
- **Enter / ⇧Enter** — Navigate between results
- **Escape** — Close search bar
- Matching text highlighted with `<mark>` tags
- Active result gets a yellow ring indicator
- Result counter shows "3 of 12" style navigation
- Scope toggle between "This chat" and "All chats"

### Implementation
- **New hook:** `use-chat-search.ts` — manages search state, keyboard shortcuts, debounced global search
- **New component:** `chat-search-bar.tsx` — search bar UI with Hugeicons, scope toggle, nav arrows
- **New API:** `/api/search` — server-side global search across sessions (searches up to 20 sessions)
- **Modified:** `message-item.tsx` — added `searchHighlight` + `isSearchActive` props with text highlighting
- **Modified:** `chat-message-list.tsx` — passes search props to message items
- **Modified:** `chat-screen.tsx` — integrates search hook + renders search bar

### Design
- Uses existing UI patterns and Tailwind classes
- Icons from `@hugeicons/core-free-icons`
- Minimal, clean — no heavy dependencies added

Relates to the idea in PR #9.