### PR TITLE
feat: add text size setting (S / M / L / XL)

### DIFF
--- a/apps/webclaw/src/components/prompt-kit/code-block/index.tsx
+++ b/apps/webclaw/src/components/prompt-kit/code-block/index.tsx
@@ -35,7 +35,7 @@ import langTypescript from '@shikijs/langs/typescript'
 import langTsx from '@shikijs/langs/tsx'
 import langXml from '@shikijs/langs/xml'
 import langYaml from '@shikijs/langs/yaml'
-import { useResolvedTheme } from '@/hooks/use-chat-settings'
+import { useResolvedTheme, useChatSettingsStore, TEXT_SIZE_CLASSES } from '@/hooks/use-chat-settings'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { formatLanguageName, normalizeLanguage, resolveLanguage } from './utils'
@@ -97,6 +97,8 @@ export function CodeBlock({
   className,
 }: CodeBlockProps) {
   const resolvedTheme = useResolvedTheme()
+  const textSize = useChatSettingsStore((s) => s.settings.textSize)
+  const codeSizeClass = TEXT_SIZE_CLASSES[textSize]
   const [copied, setCopied] = useState(false)
   const [html, setHtml] = useState<string | null>(null)
   const [resolvedLanguage, setResolvedLanguage] = useState('text')
@@ -179,7 +181,8 @@ export function CodeBlock({
       {html ? (
         <div
           className={cn(
-            'text-sm text-primary-900 [&>pre]:overflow-x-auto',
+            codeSizeClass,
+            'text-primary-900 [&>pre]:overflow-x-auto',
             isSingleLine
               ? '[&>pre]:whitespace-pre [&>pre]:px-3 [&>pre]:py-2'
               : '[&>pre]:px-3 [&>pre]:py-3',
@@ -189,7 +192,7 @@ export function CodeBlock({
       ) : (
         <pre
           className={cn(
-            'text-sm',
+            codeSizeClass,
             isSingleLine ? 'whitespace-pre px-3 py-2' : 'px-3 py-3',
           )}
         >

--- a/apps/webclaw/src/hooks/use-chat-settings.ts
+++ b/apps/webclaw/src/hooks/use-chat-settings.ts
@@ -3,11 +3,20 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
 export type ThemeMode = 'system' | 'light' | 'dark'
+export type TextSize = 'sm' | 'md' | 'lg' | 'xl'
+
+export const TEXT_SIZE_CLASSES: Record<TextSize, string> = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-lg',
+  xl: 'text-xl',
+}
 
 export type ChatSettings = {
   showToolMessages: boolean
   showReasoningBlocks: boolean
   theme: ThemeMode
+  textSize: TextSize
 }
 
 type ChatSettingsState = {
@@ -22,6 +31,7 @@ export const useChatSettingsStore = create<ChatSettingsState>()(
         showToolMessages: true,
         showReasoningBlocks: true,
         theme: 'system',
+        textSize: 'md',
       },
       updateSettings: (updates) =>
         set((state) => ({

--- a/apps/webclaw/src/screens/chat/components/message-item.tsx
+++ b/apps/webclaw/src/screens/chat/components/message-item.tsx
@@ -10,7 +10,7 @@ import type { ToolPart } from '@/components/prompt-kit/tool'
 import { Message, MessageContent } from '@/components/prompt-kit/message'
 import { Thinking } from '@/components/prompt-kit/thinking'
 import { Tool } from '@/components/prompt-kit/tool'
-import { useChatSettings } from '@/hooks/use-chat-settings'
+import { useChatSettings, TEXT_SIZE_CLASSES } from '@/hooks/use-chat-settings'
 import { cn } from '@/lib/utils'
 
 type MessageItemProps = {
@@ -176,6 +176,7 @@ function MessageItemComponent({
   const images = imagesFromMessage(message)
   const isUser = role === 'user'
   const timestamp = getMessageTimestamp(message)
+  const textSizeClass = TEXT_SIZE_CLASSES[settings.textSize]
 
   // Get tool calls from this message (for assistant messages)
   const toolCalls = role === 'assistant' ? getToolCallsFromMessage(message) : []
@@ -221,6 +222,7 @@ function MessageItemComponent({
           markdown={!isUser}
           className={cn(
             'text-primary-900',
+            textSizeClass,
             !isUser
               ? 'bg-transparent w-full'
               : 'bg-primary-100 px-4 py-2.5 max-w-[85%]',

--- a/apps/webclaw/src/screens/chat/components/settings-dialog.tsx
+++ b/apps/webclaw/src/screens/chat/components/settings-dialog.tsx
@@ -16,7 +16,7 @@ import {
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsList, TabsTab } from '@/components/ui/tabs'
 import { useChatSettings } from '@/hooks/use-chat-settings'
-import type { ThemeMode } from '@/hooks/use-chat-settings'
+import type { ThemeMode, TextSize } from '@/hooks/use-chat-settings'
 import { Button } from '@/components/ui/button'
 
 type SettingsSectionProps = {
@@ -74,6 +74,12 @@ export function SettingsDialog({
     { value: 'system', label: 'System', icon: ComputerIcon },
     { value: 'light', label: 'Light', icon: Sun01Icon },
     { value: 'dark', label: 'Dark', icon: Moon01Icon },
+  ] as const
+  const textSizeOptions = [
+    { value: 'sm', label: 'S' },
+    { value: 'md', label: 'M' },
+    { value: 'lg', label: 'L' },
+    { value: 'xl', label: 'XL' },
   ] as const
   function applyTheme(theme: ThemeMode) {
     if (typeof document === 'undefined') return
@@ -145,6 +151,25 @@ export function SettingsDialog({
                         size={20}
                         strokeWidth={1.5}
                       />
+                      <span>{option.label}</span>
+                    </TabsTab>
+                  ))}
+                </TabsList>
+              </Tabs>
+            </SettingsRow>
+            <SettingsRow label="Text size">
+              <Tabs
+                value={settings.textSize}
+                onValueChange={(value) => {
+                  updateSettings({ textSize: value as TextSize })
+                }}
+              >
+                <TabsList
+                  variant="default"
+                  className="gap-2 *:data-[slot=tab-indicator]:duration-0"
+                >
+                  {textSizeOptions.map((option) => (
+                    <TabsTab key={option.value} value={option.value}>
                       <span>{option.label}</span>
                     </TabsTab>
                   ))}


### PR DESCRIPTION
## What

Adds a configurable text size setting with four options: S, M, L, XL.

### Changes

1. **`use-chat-settings.ts`** — Added `TextSize` type (`'sm' | 'md' | 'lg' | 'xl'`) and `TEXT_SIZE_CLASSES` mapping to Tailwind classes. Added `textSize` field to settings store with default `'md'`.

2. **`settings-dialog.tsx`** — Added "Text size" row in the Appearance section with a segmented `Tabs` control (S / M / L / XL), matching the existing Theme selector pattern exactly.

3. **`message-item.tsx`** — Applied dynamic `textSizeClass` to `MessageContent` so all chat messages respect the setting.

4. **`code-block/index.tsx`** — Replaced hardcoded `text-sm` with dynamic size class so code blocks also follow the text size preference.

### Size mapping
| Setting | Tailwind class | Size |
|---------|---------------|------|
| S | `text-sm` | 14px |
| M (default) | `text-base` | 16px |
| L | `text-lg` | 18px |
| XL | `text-xl` | 20px |

Minimal changes (4 files, ~45 lines added). Relates to the idea in PR #11.