### PR TITLE
feat: add image attachments with client-side compression

### DIFF
--- a/apps/webclaw/src/lib/image-compress.ts
+++ b/apps/webclaw/src/lib/image-compress.ts
@@ -1,0 +1,72 @@
+type CompressedImage = {
+  mimeType: string
+  content: string // base64
+}
+
+const MAX_DIMENSION = 1280
+const INITIAL_QUALITY = 0.75
+const TARGET_SIZE_BYTES = 300_000 // ~300KB -> ~400KB base64 -> under 512KB WS limit
+
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error('Failed to load image'))
+    img.src = URL.createObjectURL(file)
+  })
+}
+
+function resizeAndCompress(
+  img: HTMLImageElement,
+  maxDim: number,
+  quality: number,
+): HTMLCanvasElement {
+  let { width, height } = img
+  if (width > maxDim || height > maxDim) {
+    const ratio = Math.min(maxDim / width, maxDim / height)
+    width = Math.round(width * ratio)
+    height = Math.round(height * ratio)
+  }
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas 2D context unavailable')
+  ctx.drawImage(img, 0, 0, width, height)
+  return canvas
+}
+
+function canvasToBase64(canvas: HTMLCanvasElement, quality: number): string {
+  const dataUrl = canvas.toDataURL('image/jpeg', quality)
+  return dataUrl.split(',')[1] ?? ''
+}
+
+function base64ByteSize(base64: string): number {
+  return Math.ceil((base64.length * 3) / 4)
+}
+
+export async function compressImage(file: File): Promise<CompressedImage> {
+  const img = await loadImage(file)
+  const canvas = resizeAndCompress(img, MAX_DIMENSION, INITIAL_QUALITY)
+
+  // Progressive quality reduction if over target
+  let quality = INITIAL_QUALITY
+  let base64 = canvasToBase64(canvas, quality)
+
+  while (base64ByteSize(base64) > TARGET_SIZE_BYTES && quality > 0.3) {
+    quality -= 0.1
+    base64 = canvasToBase64(canvas, quality)
+  }
+
+  // Clean up object URL
+  URL.revokeObjectURL(img.src)
+
+  return {
+    mimeType: 'image/jpeg',
+    content: base64,
+  }
+}
+
+export function isImageFile(file: File): boolean {
+  return file.type.startsWith('image/')
+}

--- a/apps/webclaw/src/routes/api/send.ts
+++ b/apps/webclaw/src/routes/api/send.ts
@@ -63,6 +63,10 @@ export const Route = createFileRoute('/api/send')({
             sessionKey,
             message,
             thinking,
+            attachments:
+              Array.isArray(body.attachments) && body.attachments.length > 0
+                ? body.attachments
+                : undefined,
             deliver: false,
             timeoutMs: 120_000,
             idempotencyKey:

--- a/apps/webclaw/src/screens/chat/chat-screen.tsx
+++ b/apps/webclaw/src/screens/chat/chat-screen.tsx
@@ -348,6 +348,7 @@ export function ChatScreen({
     friendlyId: string,
     body: string,
     skipOptimistic = false,
+    attachments?: Array<{ mimeType: string; content: string }>,
   ) {
     let optimisticClientId = ''
     if (!skipOptimistic) {
@@ -381,6 +382,7 @@ export function ChatScreen({
         friendlyId,
         message: body,
         thinking: 'low',
+        attachments,
         idempotencyKey: crypto.randomUUID(),
       }),
     })
@@ -449,8 +451,13 @@ export function ChatScreen({
   }, [queryClient])
 
   const send = useCallback(
-    (body: string, helpers: ChatComposerHelpers) => {
-      if (body.length === 0) return
+    (
+      body: string,
+      helpers: ChatComposerHelpers,
+      attachments?: Array<{ mimeType: string; content: string }>,
+    ) => {
+      if (body.length === 0 && (!attachments || attachments.length === 0))
+        return
       helpers.reset()
 
       if (isNewChat) {
@@ -503,7 +510,13 @@ export function ChatScreen({
 
       const sessionKeyForSend =
         forcedSessionKey || resolvedSessionKey || activeSessionKey
-      sendMessage(sessionKeyForSend, activeFriendlyId, body)
+      sendMessage(
+        sessionKeyForSend,
+        activeFriendlyId,
+        body,
+        false,
+        attachments,
+      )
     },
     [
       activeFriendlyId,

--- a/apps/webclaw/src/screens/chat/components/chat-composer.tsx
+++ b/apps/webclaw/src/screens/chat/components/chat-composer.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useRef, useState } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { ArrowUp02Icon } from '@hugeicons/core-free-icons'
+import { ArrowUp02Icon, Attachment01Icon, Cancel01Icon } from '@hugeicons/core-free-icons'
 import type { Ref } from 'react'
 
 import {
@@ -10,9 +10,21 @@ import {
   PromptInputTextarea,
 } from '@/components/prompt-kit/prompt-input'
 import { Button } from '@/components/ui/button'
+import { compressImage, isImageFile } from '@/lib/image-compress'
+
+type CompressedAttachment = {
+  mimeType: string
+  content: string
+  preview: string // data URL for preview
+  name: string
+}
 
 type ChatComposerProps = {
-  onSubmit: (value: string, helpers: ChatComposerHelpers) => void
+  onSubmit: (
+    value: string,
+    helpers: ChatComposerHelpers,
+    attachments?: Array<{ mimeType: string; content: string }>,
+  ) => void
   isLoading: boolean
   disabled: boolean
   wrapperRef?: Ref<HTMLDivElement>
@@ -30,7 +42,10 @@ function ChatComposerComponent({
   wrapperRef,
 }: ChatComposerProps) {
   const [value, setValue] = useState('')
+  const [attachments, setAttachments] = useState<Array<CompressedAttachment>>([])
+  const [compressing, setCompressing] = useState(false)
   const promptRef = useRef<HTMLTextAreaElement | null>(null)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
   const focusPrompt = useCallback(() => {
     if (typeof window === 'undefined') return
     window.requestAnimationFrame(() => {
@@ -39,6 +54,7 @@ function ChatComposerComponent({
   }, [])
   const reset = useCallback(() => {
     setValue('')
+    setAttachments([])
     focusPrompt()
   }, [focusPrompt])
   const setComposerValue = useCallback(
@@ -48,20 +64,123 @@ function ChatComposerComponent({
     },
     [focusPrompt],
   )
+
+  const addFiles = useCallback(async (files: FileList | File[]) => {
+    const imageFiles = Array.from(files).filter(isImageFile)
+    if (imageFiles.length === 0) return
+    setCompressing(true)
+    try {
+      const compressed = await Promise.all(
+        imageFiles.map(async (file) => {
+          const result = await compressImage(file)
+          return {
+            ...result,
+            preview: `data:${result.mimeType};base64,${result.content}`,
+            name: file.name,
+          }
+        }),
+      )
+      setAttachments((prev) => [...prev, ...compressed])
+    } finally {
+      setCompressing(false)
+    }
+  }, [])
+
+  const removeAttachment = useCallback((index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index))
+  }, [])
+
   const handleSubmit = useCallback(() => {
     if (disabled) return
     const body = value.trim()
-    if (body.length === 0) return
-    onSubmit(body, { reset, setValue: setComposerValue })
+    if (body.length === 0 && attachments.length === 0) return
+    const atts =
+      attachments.length > 0
+        ? attachments.map((a) => ({ mimeType: a.mimeType, content: a.content }))
+        : undefined
+    onSubmit(body || '(image)', { reset, setValue: setComposerValue }, atts)
     focusPrompt()
-  }, [disabled, focusPrompt, onSubmit, reset, setComposerValue, value])
-  const submitDisabled = disabled || value.trim().length === 0
+  }, [
+    disabled,
+    focusPrompt,
+    onSubmit,
+    reset,
+    setComposerValue,
+    value,
+    attachments,
+  ])
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const items = e.clipboardData?.items
+      if (!items) return
+      const imageFiles: File[] = []
+      for (const item of Array.from(items)) {
+        if (item.type.startsWith('image/')) {
+          const file = item.getAsFile()
+          if (file) imageFiles.push(file)
+        }
+      }
+      if (imageFiles.length > 0) {
+        e.preventDefault()
+        addFiles(imageFiles)
+      }
+    },
+    [addFiles],
+  )
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      if (e.dataTransfer?.files) {
+        addFiles(e.dataTransfer.files)
+      }
+    },
+    [addFiles],
+  )
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+  }, [])
+
+  const submitDisabled =
+    disabled || (value.trim().length === 0 && attachments.length === 0)
 
   return (
     <div
       className="mx-auto w-full max-w-full px-5 sm:max-w-[768px] sm:min-w-[400px] relative pb-3"
       ref={wrapperRef}
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
     >
+      {/* Attachment previews */}
+      {attachments.length > 0 && (
+        <div className="flex gap-2 mb-2 flex-wrap">
+          {attachments.map((att, i) => (
+            <div key={i} className="relative group">
+              <img
+                src={att.preview}
+                alt={att.name}
+                className="h-16 w-16 object-cover rounded-lg border border-primary-200"
+              />
+              <button
+                type="button"
+                onClick={() => removeAttachment(i)}
+                className="absolute -top-1.5 -right-1.5 bg-primary-800 text-white rounded-full p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+                aria-label={`Remove ${att.name}`}
+              >
+                <HugeiconsIcon icon={Cancel01Icon} size={12} strokeWidth={2} />
+              </button>
+            </div>
+          ))}
+          {compressing && (
+            <div className="h-16 w-16 flex items-center justify-center rounded-lg border border-primary-200 bg-primary-50">
+              <span className="text-xs text-primary-500">…</span>
+            </div>
+          )}
+        </div>
+      )}
+
       <PromptInput
         value={value}
         onValueChange={setValue}
@@ -72,8 +191,25 @@ function ChatComposerComponent({
         <PromptInputTextarea
           placeholder="Type a message…"
           inputRef={promptRef}
+          onPaste={handlePaste}
         />
         <PromptInputActions className="justify-end px-3">
+          <PromptInputAction tooltip="Attach image">
+            <Button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={disabled}
+              size="icon-sm"
+              variant="ghost"
+              className="text-primary-500 hover:text-primary-700"
+              aria-label="Attach image"
+            >
+              <HugeiconsIcon
+                icon={Attachment01Icon}
+                size={18}
+                strokeWidth={1.6}
+              />
+            </Button>
+          </PromptInputAction>
           <PromptInputAction tooltip="Send message">
             <Button
               onClick={handleSubmit}
@@ -87,6 +223,18 @@ function ChatComposerComponent({
           </PromptInputAction>
         </PromptInputActions>
       </PromptInput>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/gif,image/webp"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          if (e.target.files) addFiles(e.target.files)
+          e.target.value = ''
+        }}
+      />
     </div>
   )
 }

--- a/apps/webclaw/src/screens/chat/types.ts
+++ b/apps/webclaw/src/screens/chat/types.ts
@@ -27,7 +27,19 @@ export type ThinkingContent = {
   thinkingSignature?: string
 }
 
-export type MessageContent = TextContent | ToolCallContent | ThinkingContent
+export type ImageContent = {
+  type: 'image'
+  mimeType?: string
+  data?: string
+  content?: string
+  source?: { type?: string; media_type?: string; data?: string }
+}
+
+export type MessageContent =
+  | TextContent
+  | ToolCallContent
+  | ThinkingContent
+  | ImageContent
 
 export type GatewayMessage = {
   role?: string


### PR DESCRIPTION
## What

Adds image attachment support to the chat composer, addressing Issue #3.

### Features
- 📎 **Attachment button** in the composer (paperclip icon)
- **Drag & drop** images onto the composer
- **Paste from clipboard** (Ctrl+V / ⌘V)
- **Client-side compression** — resizes to max 1280px, JPEG at 75% quality, progressive reduction if over 300KB (stays under Gateway's 512KB WebSocket limit)
- **Preview thumbnails** before sending with remove button
- **Image display** in chat history — clickable thumbnails that open full size
- Supports PNG, JPG, GIF, WebP input (compressed to JPEG for transport)

### Implementation

1. **`apps/webclaw/src/lib/image-compress.ts`** (new) — Canvas-based resize + JPEG compression with progressive quality reduction
2. **`apps/webclaw/src/screens/chat/components/chat-composer.tsx`** — Added attachment button, file input, drag-drop, clipboard paste, preview grid
3. **`apps/webclaw/src/routes/api/send.ts`** — Passes `attachments` array through to Gateway RPC
4. **`apps/webclaw/src/screens/chat/chat-screen.tsx`** — Updated `send` and `sendMessage` signatures to accept attachments
5. **`apps/webclaw/src/screens/chat/components/message-item.tsx`** — Renders image parts from message content as clickable thumbnails
6. **`apps/webclaw/src/screens/chat/types.ts`** — Added `ImageContent` type

### Compression strategy
- Max dimension: 1280px (maintains aspect ratio)
- Initial JPEG quality: 75%
- Target size: ~300KB (→ ~400KB base64 → under 512KB WS limit)
- Progressive quality reduction (down to 30%) if still over target

Closes #3.