### PR TITLE
fix: attachment button click not triggering file input

### DIFF
--- a/apps/webclaw/src/components/attachment-button.tsx
+++ b/apps/webclaw/src/components/attachment-button.tsx
@@ -267,6 +267,7 @@ export function AttachmentButton({
         aria-hidden="true"
       />
       <Button
+        {...buttonProps}
         variant={buttonProps?.variant ?? 'ghost'}
         size={buttonProps?.size ?? 'icon-sm'}
         onClick={(event) => {
@@ -277,7 +278,6 @@ export function AttachmentButton({
         className={cn('rounded-full', buttonProps?.className)}
         aria-label="Attach image"
         type={buttonProps?.type ?? 'button'}
-        {...buttonProps}
       >
         <HugeiconsIcon icon={PlusSignIcon} size={20} strokeWidth={1.5} />
       </Button>


### PR DESCRIPTION
## Problem
Fixes #38：
Move {...buttonProps} before explicit props to prevent onClick override. The spread was overriding the handleClick() call that triggers the file input.

## Testing
Verified the attachment button now opens the file picker
<img width="3024" height="1716" alt="image" src="https://github.com/user-attachments/assets/8ae06dd9-fa08-4ec4-96d2-49e7d5c13da6" />
<img width="3024" height="1716" alt="image" src="https://github.com/user-attachments/assets/453cd7ee-7ac2-4e0d-8447-63ce84309935" />

